### PR TITLE
FFS-2170: Header-basert ingress-routing for Bearer/M2M ved siden av SSO-cookie

### DIFF
--- a/kustomize/base/flais.yaml
+++ b/kustomize/base/flais.yaml
@@ -27,10 +27,15 @@ spec:
     hostname: flyt.vigoiks.no
     basePath: ""
   ingress:
-    enabled: true
-    basePath: path
-    middlewares:
-      - fint-flyt-auth-forward-sso
+    routes:
+      - host: flyt.vigoiks.no
+        path: path
+        headers:
+          Authorization: "re:.+"
+      - host: flyt.vigoiks.no
+        path: path
+        middlewares:
+          - fint-flyt-auth-forward-sso
   env:
     - name: JAVA_TOOL_OPTIONS
       value: '-XX:+ExitOnOutOfMemoryError -Xmx576M -Xms384M'

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/afk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/afk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "afk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/afk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/afk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/agderfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/agderfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "agderfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/agderfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/agderfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/bfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/bfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/bym-oslo-kommune-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/bym-oslo-kommune-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ffk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ffk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ffk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ffk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ffk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "fintlabs.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/fintlabs-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/fintlabs-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/innlandetfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/innlandetfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "innlandetfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/innlandetfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/innlandetfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "mrfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/mrfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/mrfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "nfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/nfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/nfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/ofk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/ofk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "ofk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/ofk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/ofk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/rogfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/rogfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "rogfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/rogfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/rogfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/telemarkfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/telemarkfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "telemarkfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/telemarkfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/telemarkfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/tromsfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/tromsfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "tromsfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/tromsfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/tromsfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/trondelagfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/trondelagfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "trondelagfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/trondelagfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/trondelagfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vestfoldfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vestfoldfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vestfoldfylke.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vestfoldfylke-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vestfoldfylke-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/vlfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/vlfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "vlfk.no"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "/beta/vlfk-no/api/intern/handlinger/instanser"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "/beta/vlfk-no/api/intern/handlinger/instanser"
       - op: add
         path: "/spec/env/-"

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -19,7 +19,10 @@ patches:
         path: "/spec/orgId"
         value: "$ORG_ID_DOT"
       - op: replace
-        path: "/spec/ingress/basePath"
+        path: "/spec/ingress/routes/0/path"
+        value: "$INGRESS_BASE_PATH"
+      - op: replace
+        path: "/spec/ingress/routes/1/path"
         value: "$INGRESS_BASE_PATH"
       - op: add
         path: "/spec/env/-"


### PR DESCRIPTION
## Summary

Legger til en middleware-fri ingress-rute som lar API-et tas med `Authorization: Bearer` direkte (M2M/client-credentials, eller en omskrevet frontend), ved siden av dagens SSO-cookie-flyt via `fint-flyt-auth-forward-sso`.

Tjenesten er allerede OAuth2 resource server (`no.novari:flyt-web-resource-server`) og validerer JWT-en selv, uavhengig av SSO-middlewaren — dette er derfor en ren ingress/konfig-endring, ingen backend-kode er rørt.

- `kustomize/base/flais.yaml`: bytter fra legacy `ingress.enabled/basePath/middlewares` til `ingress.routes` (flaiserator routes-form) med to ruter på samme host/path:
  - én rute matcher `Authorization: re:.+` (HeadersRegexp) og har ingen middleware — treffer requests med Bearer-token direkte.
  - én fallback-rute med `middlewares: [fint-flyt-auth-forward-sso]` — dagens cookie-baserte flyt, uendret oppførsel for eksisterende frontend.
  - Traefik prioriterer på regel-lengde, så header-regelen (lengre) vinner automatisk når `Authorization` er satt; requests uten header treffer SSO-fallback.
- `kustomize/templates/overlay.yaml.tpl`: patcher nå `/spec/ingress/routes/0/path` og `/spec/ingress/routes/1/path` (samme verdi) i stedet for `/spec/ingress/basePath`.
- Alle 27 tenant-overlays er regenerert via `script/render-overlay.sh` fra oppdatert template — ingen manuelle endringer i overlay-filene.

Verifisert at `kubectl kustomize` bygger feilfritt for samtlige overlays, og at begge ruter rendres med korrekt per-tenant path (spot-sjekket agderfk-no api/beta og bym-oslo-kommune-no).

Ref: FFS-2170 (epic FFS-2164) — https://novari-iks.atlassian.net/browse/FFS-2170