### PR TITLE
FFS-2225 Aktiver sporing og JSON-logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation("no.novari:flyt-audit-starter:1.1.0")
     implementation("no.novari:flyt-kafka:7.3.0-rc-2")
     implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
-    implementation("no.novari:telemetry-starter:0.0.3")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation("no.novari:flyt-audit-starter:1.1.0")
     implementation("no.novari:flyt-kafka:7.3.0-rc-2")
     implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
-    implementation("no.novari:telemetry-starter:0.0.4")
+    implementation("no.novari:telemetry-starter:0.0.5")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     compileOnly("org.springframework.security:spring-security-config")
     compileOnly("org.springframework.security:spring-security-web")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,10 +46,12 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
 
     implementation("no.novari:flyt-audit-starter:1.1.0")
-    implementation("no.novari:flyt-kafka:7.2.0")
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
+    implementation("no.novari:flyt-kafka:7.3.0-rc-2")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:telemetry-starter:0.0.3")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/afk-no"
       - op: replace

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -58,6 +58,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/afk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/afk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/agderfk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/agderfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/agderfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -58,6 +58,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/bfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/bfk-no"
       - op: replace

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bym.oslo.kommune.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bym-oslo-kommune-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/ffk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/fintlabs-no"
       - op: replace

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/fintlabs-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/innlandetfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/mrfylke-no"
       - op: replace

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/nfk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -58,6 +58,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/ofk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ofk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/rogfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/telemarkfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/tromsfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/trondelagfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/vestfoldfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vlfk-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/vlfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vlfk-no"
       - op: replace

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -38,6 +38,11 @@ $ROLE_MAPPING
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "$ORG_ID_DOT"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "$BASE_PATH"
       - op: replace

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -51,7 +51,7 @@ $ROLE_MAPPING
         value: "$LIVENESS_PATH"
       - op: replace
         path: "/spec/observability/metrics/path"
-        value: "$METRICS_PATH"
+        value: "$METRICS_PATH"$OTEL_ENV_PATCH
     target:
       kind: Application
       name: fint-flyt-instance-service

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -7,6 +7,21 @@ TEMPLATE_PATH="$ROOT/kustomize/templates/overlay.yaml.tpl"
 ROLE_CATALOG_USER_URL="USER"
 ROLE_CATALOG_DEVELOPER_URL="DEVELOPER"
 
+OTEL_ENDPOINT_BETA="http://alloy.flais-system.svc.cluster.local:4318"
+
+# Base-URL uten /v1/traces: telemetry-starter legger på signal-stien selv.
+# Settes manuelt inntil flaiserator har støtte for det, og kun i beta der Alloy kjører.
+build_otel_env_patch() {
+  local environment="$1"
+
+  if [[ "$environment" != "beta" ]]; then
+    return
+  fi
+
+  printf '\n      - op: add\n        path: "/spec/env/-"\n        value:\n          name: "OTEL_EXPORTER_OTLP_ENDPOINT"\n          value: "%s"' \
+    "$OTEL_ENDPOINT_BETA"
+}
+
 build_role_mapping() {
   local namespace="$1"
   local org_id_dot="$2"
@@ -72,6 +87,7 @@ while IFS= read -r file; do
   export LIVENESS_PATH="${base_path}/actuator/health/liveness"
   export METRICS_PATH="${base_path}/actuator/prometheus"
   export FINT_KAFKA_TOPIC_ORGID="${namespace}"
+  export OTEL_ENV_PATCH="$(build_otel_env_patch "$environment")"
 
   export ROLE_MAPPING="$(build_role_mapping "$namespace" "$ORG_ID_DOT")"
   if [[ -z "$ROLE_MAPPING" ]]; then

--- a/src/main/kotlin/no/novari/flyt/instance/InstanceCleanupService.kt
+++ b/src/main/kotlin/no/novari/flyt/instance/InstanceCleanupService.kt
@@ -1,6 +1,6 @@
 package no.novari.flyt.instance
 
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -11,11 +11,14 @@ class InstanceCleanupService(
     private val timeToKeepInstancesInDays: Int,
     private val instanceService: InstanceService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = KotlinLogging.logger {}
 
     @Scheduled(initialDelay = 30000, fixedDelay = 86400000)
     fun cleanUp() {
-        log.info("Cleaning up instances older than {} days", timeToKeepInstancesInDays)
+        log.atInfo {
+            message = "Cleaning up instances older than {} days"
+            arguments = arrayOf(timeToKeepInstancesInDays)
+        }
         instanceService.deleteAllOlderThan(timeToKeepInstancesInDays)
     }
 }

--- a/src/main/kotlin/no/novari/flyt/instance/InstanceRetryController.kt
+++ b/src/main/kotlin/no/novari/flyt/instance/InstanceRetryController.kt
@@ -1,12 +1,12 @@
 package no.novari.flyt.instance
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.persistence.EntityNotFoundException
 import no.novari.flyt.instance.kafka.InstanceFlowHeadersForRegisteredInstanceRequestProducerService
 import no.novari.flyt.instance.kafka.InstanceRequestedForRetryEventProducerService
 import no.novari.flyt.instance.kafka.InstanceRetryRequestErrorProducerService
 import no.novari.flyt.kafka.instanceflow.headers.InstanceFlowHeaders
 import no.novari.flyt.webresourceserver.UrlPaths.INTERNAL_API
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,7 +26,7 @@ class InstanceRetryController(
     private val instanceRequestedForRetryEventProducerService: InstanceRequestedForRetryEventProducerService,
     private val instanceRetryRequestErrorProducerService: InstanceRetryRequestErrorProducerService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = KotlinLogging.logger {}
 
     @PostMapping("handlinger/instanser/{instanceId}/prov-igjen")
     fun retry(
@@ -75,12 +75,15 @@ class InstanceRetryController(
 
                 instanceRequestedForRetryEventProducerService.publish(instanceFlowHeaders, instance)
             } catch (_: EntityNotFoundException) {
-                log.error("Could not find instance with id='{}'", instanceId)
+                log.atError {
+                    message = "Could not find instance with id='{}'"
+                    arguments = arrayOf(instanceId)
+                }
             } catch (e: NoInstanceFlowHeadersException) {
-                log.error(e.message)
+                log.atError { message = e.message }
             } catch (e: Exception) {
                 instanceFlowHeaders?.let(instanceRetryRequestErrorProducerService::publishGeneralSystemErrorEvent)
-                log.error(e.message)
+                log.atError { message = e.message }
             }
         }
 

--- a/src/main/kotlin/no/novari/flyt/instance/InstanceService.kt
+++ b/src/main/kotlin/no/novari/flyt/instance/InstanceService.kt
@@ -1,11 +1,11 @@
 package no.novari.flyt.instance
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.instance.kafka.InstanceDeletedEventProducerService
 import no.novari.flyt.instance.kafka.InstanceFlowHeadersForRegisteredInstanceRequestProducerService
 import no.novari.flyt.instance.model.InstanceMappingService
 import no.novari.flyt.instance.model.dtos.InstanceObjectDto
 import no.novari.flyt.kafka.instanceflow.headers.InstanceFlowHeaders
-import org.slf4j.LoggerFactory
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.stereotype.Service
 import java.time.Instant
@@ -19,7 +19,7 @@ class InstanceService(
     private val instanceFlowHeadersForRegisteredInstanceRequestProducerService:
         InstanceFlowHeadersForRegisteredInstanceRequestProducerService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = KotlinLogging.logger {}
 
     fun save(instanceObjectDto: InstanceObjectDto): InstanceObjectDto {
         return instanceMappingService.toInstanceObjectDto(
@@ -43,22 +43,35 @@ class InstanceService(
         getAllOlderThan(days).forEach { instance ->
             val instanceId = instance.id
             if (instanceId == null) {
-                log.warn("Instance without id encountered during cleanup")
+                log.atWarn { message = "Instance without id encountered during cleanup" }
                 return@forEach
             }
 
             instanceFlowHeadersForRegisteredInstanceRequestProducerService
                 .get(instanceId)
                 ?.let(instanceDeletedEventProducerService::publish)
-                ?: log.warn("No instance flow headers found for instance with id={}", instanceId)
+                ?: log.atWarn {
+                    message = "No instance flow headers found for instance with id={}"
+                    arguments = arrayOf(instanceId)
+                }
 
             try {
                 instanceRepository.deleteById(instanceId)
-                log.info("Instance with id={} deleted", instanceId)
+                log.atInfo {
+                    message = "Instance with id={} deleted"
+                    arguments = arrayOf(instanceId)
+                }
             } catch (_: EmptyResultDataAccessException) {
-                log.warn("Instance with id={} was already deleted", instanceId)
+                log.atWarn {
+                    message = "Instance with id={} was already deleted"
+                    arguments = arrayOf(instanceId)
+                }
             } catch (e: Exception) {
-                log.error("Failed to delete instance with id={}", instanceId, e)
+                log.atError {
+                    message = "Failed to delete instance with id={}"
+                    arguments = arrayOf(instanceId)
+                    cause = e
+                }
             }
         }
     }

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,8 @@ server:
     include-message: always
 
 spring:
+  application:
+    name: ${fint.application-id}
   profiles:
     include:
       - flyt-kafka

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Sammendrag

- Legger til `telemetry-starter` for HTTP-selvinstrumentering
- Bumper `flyt-kafka` og `flyt-web-resource-server` til versjoner med Kafka-sporing (`novari.kafka.tracing.enabled=true`) og korrekt trace-propagering — instance-service er den sentrale noden i instansflyten, så producer/consumer-spenn herfra binder sammen sporet gjennom Kafka
- Legger til JSON-logging (var ikke i bruk fra før) med telemetry-starter sitt loggfragment, slik at `traceId`/`spanId` blir søkbare
- Konverterer eksisterende SLF4J-bruk (`InstanceService`, `InstanceCleanupService`, `InstanceRetryController`) til `kotlin-logging`, samme mønster som de andre flyt-repoene (egen commit)

Del av OpenTelemetry-tracing-epicen (FFS-2196).