### PR TITLE
FFS-2278 Overstyr sårbare avhengigheter på buildscript-classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,18 @@
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath(platform("com.fasterxml.jackson:jackson-bom:2.22.2"))
+        constraints {
+            classpath("org.apache.httpcomponents.client5:httpclient5:5.6.4")
+            classpath("org.apache.httpcomponents.core5:httpcore5:5.4.3")
+            classpath("org.apache.httpcomponents.core5:httpcore5-h2:5.4.3")
+            classpath("org.apache.commons:commons-lang3:3.18.0")
+        }
+    }
+}
+
 plugins {
     id("org.springframework.boot") version "3.5.16"
     id("io.spring.dependency-management") version "1.1.7"


### PR DESCRIPTION
## Sammendrag

Lukker Dependabot-varslene for `httpclient5`, `httpcore5`, `httpcore5-h2`, `jackson-databind` og `commons-lang3` ved å legge dependency constraints på Gradle sin `classpath`-konfigurasjon.

Ingen av dem er runtime-sårbarheter. Versjonene kommer fra **plugin-classpath**, dratt inn av `spring-boot-gradle-plugin:3.5.16`:

```
spring-boot-gradle-plugin:3.5.16
├── spring-boot-buildpack-platform      ← brukes kun av bootBuildImage (ikke i bruk hos oss)
│   ├── httpclient5:5.5.2 → httpcore5-h2:5.3.6 → httpcore5:5.3.6
│   ├── jackson-databind:2.21.4
│   └── commons-compress:1.27.1 → commons-lang3:3.16.0
└── spring-boot-loader-tools            ← brukes av bootJar
    └── commons-compress:1.27.1 → commons-lang3:3.16.0
```

`extra[...]`-overstyringene er en `io.spring.dependency-management`-property som kun virker på prosjektets egne konfigurasjoner. Den treffer aldri buildscript-classpath, og derfor har varslene blitt stående selv om applikasjonen for lengst er patchet.

Bumping løser det ikke: 3.5.16 er siste utgivelse i 3.5-serien, og 4.1.1 fikser kun `httpclient5` — den pinner fortsatt `commons-compress:1.27.1` → `commons-lang3:3.16.0`.

## Verifisert i malen først

Samme endring ble merget i `fint-flyt-gateway-template` og lukket 7 varsler der som `fixed` — ikke dismissed. Denne PR-en ruller ut samme blokk.

`httpclient5-parent` 5.6.4 pinner selv `httpcore5` til 5.4.3, så kombinasjonen er testet av leverandøren. `platform(...)` på jackson-bom holder `jackson-core`, `-annotations`, `-databind` og `-module-parameter-names` i takt.

Lokalt verifisert med `./gradlew buildEnvironment`: ingen 5.3.6, 5.5.2, 2.21.4 eller 3.16.0 igjen på classpath.

## Ikke med her

`kotlin-gradle-plugin` (CVE-2026-53914) står igjen. Fiksen finnes kun i pre-release — nyeste utgivelse er 2.4.20-RC. Bumpes når stabil 2.4.20 slippes.

https://novari-iks.atlassian.net/browse/FFS-2278
